### PR TITLE
Update Sous-Chefs link to work

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - 👯 I’m looking to collaborate on new and interesting projects
 - 📫 How to reach me: 🐦 @dan_webb
 - 😄 Pronouns: He/him
-- ⚡ Fun fact: I used to help run [Sous-Chefs](github.com/sous-chefs), now I just help make their CI system better.
+- ⚡ Fun fact: I used to help run [Sous-Chefs](https://github.com/sous-chefs), now I just help make their CI system better.
 
 
 


### PR DESCRIPTION
I noticed that the Sous-Chefs link was trying to go to `github.com/sous-chefs` as though it was a file in the current branch of the respository. This updates it to go to the actual location.